### PR TITLE
[refactor] (#121) try moko viewmodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GMap2iCal - Google Maps Timeline to iCal <br/>![Gradle Check on Main](https://github.com/ryanw-mobile/GMap2ICal/actions/workflows/main_build.yml/badge.svg) [![codecov](https://codecov.io/github/ryanw-mobile/GMap2ICal/graph/badge.svg?token=4NZUBRYHT0)](https://codecov.io/github/ryanw-mobile/GMap2ICal)
+# GMap2iCal - Google Maps Timeline to iCal <br/>![Gradle Build](https://github.com/ryanw-mobile/GMap2ICal/actions/workflows/main_build.yml/badge.svg) [![codecov](https://codecov.io/github/ryanw-mobile/GMap2ICal/graph/badge.svg?token=4NZUBRYHT0)](https://codecov.io/github/ryanw-mobile/GMap2ICal)
 ### My first Compose for Desktop App
 
 <p align="center">
@@ -69,6 +69,7 @@ Trying to reuse all my Android development knowledge as possible, otherwise nati
 * [Time Zone Map](https://github.com/dustin-johnson/timezonemap) - determine time zone
 * [jSystemThemeDetector](https://github.com/Dansoftowner/jSystemThemeDetector) - detect system dark theme setting
 * [Napier](https://github.com/AAkira/Napier) - Logging library for Kotlin Multiplatform
+* [MoKo MVVM](https://github.com/icerockdev/moko-mvvm) - Mobile Kotlin Model-View-ViewModel architecture components
 * [JUnit 5](https://github.com/junit-team/junit5) - Tests
 * [KOTest](https://kotest.io/) - Test framework
 * [MockK](https://mockk.io/) - Mocking library

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,10 +25,10 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
     jvm {
         compilations.all {
-            kotlinOptions.jvmTarget = "11"
+            kotlinOptions.jvmTarget = "17"
         }
         withJava()
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,8 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
 
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlin.test.junit)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.mockk)
                 implementation(libs.ktor.client.mock)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,8 +82,8 @@ kotlin {
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.serialization.kotlinx.json)
 
-                api("dev.icerock.moko:mvvm-core:0.16.1")
-                api("dev.icerock.moko:mvvm-compose:0.16.1")
+                api(libs.moko.mvvm.core)
+                api(libs.moko.mvvm.compose)
             }
         }
 
@@ -105,6 +105,8 @@ kotlin {
                 implementation(libs.kotest.runner.junit5.jvm)
                 implementation(libs.kotest.assertions.core)
                 implementation(libs.kotest.property)
+
+                implementation(libs.moko.mvvm.test)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,9 @@ kotlin {
                 implementation(libs.ktor.client.cio)
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.serialization.kotlinx.json)
+
+                api("dev.icerock.moko:mvvm-core:0.16.1")
+                api("dev.icerock.moko:mvvm-compose:0.16.1")
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kover = "0.7.5"
 mockk = "1.13.8"
 junit = "5.10.1"
 jSystemThemeDetector = "3.8"
+mokoMvvm = "0.16.1"
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -48,3 +49,6 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
 junit-vintage-engine = { group = "org.junit.vintage", name = "junit-vintage-engine", version.ref = "junit" }
 themedetector = { group = "com.github.Dansoftowner", name = "jSystemThemeDetector", version.ref = "jSystemThemeDetector" }
+moko-mvvm-core = { group = "dev.icerock.moko", name = "mvvm-core", version.ref = "mokoMvvm" }
+moko-mvvm-compose = { group = "dev.icerock.moko", name = "mvvm-compose", version.ref = "mokoMvvm" }
+moko-mvvm-test = { group = "dev.icerock.moko", name = "mvvm-test", version.ref = "mokoMvvm" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ mockk = "1.13.8"
 junit = "5.10.1"
 jSystemThemeDetector = "3.8"
 mokoMvvm = "0.16.1"
+kotlinTest = "1.8.10"
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -31,6 +32,8 @@ kotlinx-coroutines-core-jvm = { group = "org.jetbrains.kotlinx", name = "kotlinx
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotlin-test-junit =  { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlinTest" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 compose-ui-test-junit4 = { group = "org.jetbrains.compose.ui", name = "ui-test-junit4", version.ref = "compose" }
 timezonemap = { group = "us.dustinj.timezonemap", name = "timezonemap", version.ref = "timezonemap" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }

--- a/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/Main.kt
+++ b/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/Main.kt
@@ -5,6 +5,8 @@
 package uk.ryanwong.gmap2ics
 
 import androidx.compose.ui.window.application
+import dev.icerock.moko.mvvm.compose.getViewModel
+import dev.icerock.moko.mvvm.compose.viewModelFactory
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
 import io.ktor.client.engine.cio.CIO
@@ -55,11 +57,10 @@ fun main() = application {
         vEventFromChildVisitUseCase = VEventFromChildVisitUseCaseImpl(placeDetailsRepository = placeDetailsRepository),
         vEventFromPlaceVisitUseCase = VEventFromPlaceVisitUseCaseImpl(placeDetailsRepository = placeDetailsRepository),
     )
-
-    GregoryGreenTheme {
-        mainScreen(
-            onCloseRequest = { exitApplication() },
-            mainScreenViewModel = MainScreenViewModel(
+    val viewModel = getViewModel(
+        key = "main-screen",
+        factory = viewModelFactory {
+            MainScreenViewModel(
                 configFile = configFile,
                 resourceBundle = resourceBundle,
                 timelineRepository = TimelineRepositoryImpl(
@@ -74,7 +75,14 @@ fun main() = application {
                 ),
                 getOutputFilenameUseCase = GetOutputFilenameUseCaseImpl(),
                 getPlaceVisitVEventUseCase = getPlaceVisitVEventUseCase,
-            ),
+            )
+        },
+    )
+
+    GregoryGreenTheme {
+        mainScreen(
+            onCloseRequest = { exitApplication() },
+            mainScreenViewModel = viewModel,
         )
     }
 }

--- a/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
+++ b/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
@@ -4,8 +4,10 @@
 
 package uk.ryanwong.gmap2ics.ui.viewmodels
 
+import dev.icerock.moko.mvvm.viewmodel.ViewModel
+import java.nio.file.Paths
+import java.util.ResourceBundle
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,8 +24,6 @@ import uk.ryanwong.gmap2ics.app.usecases.GetPlaceVisitVEventUseCase
 import uk.ryanwong.gmap2ics.data.repository.LocalFileRepository
 import uk.ryanwong.gmap2ics.data.repository.TimelineRepository
 import uk.ryanwong.gmap2ics.ui.screens.MainScreenUIState
-import java.nio.file.Paths
-import java.util.ResourceBundle
 
 class MainScreenViewModel(
     private val configFile: Config,
@@ -35,7 +35,7 @@ class MainScreenViewModel(
     private val resourceBundle: ResourceBundle,
     private val projectBasePath: String = Paths.get("").toAbsolutePath().toString().plus("/"),
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
-) {
+) : ViewModel() {
     private var _mainScreenUIState: MutableStateFlow<MainScreenUIState> = MutableStateFlow(MainScreenUIState.Ready)
     val mainScreenUIState: StateFlow<MainScreenUIState> = _mainScreenUIState
 
@@ -67,7 +67,6 @@ class MainScreenViewModel(
     val verboseLogs: StateFlow<Boolean> = _verboseLogs
 
     private var coroutineJob: Job? = null
-    private val viewModelScope = CoroutineScope(dispatcher)
 
     init {
         // Default values, overridable from UI

--- a/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
+++ b/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
@@ -5,8 +5,6 @@
 package uk.ryanwong.gmap2ics.ui.viewmodels
 
 import dev.icerock.moko.mvvm.viewmodel.ViewModel
-import java.nio.file.Paths
-import java.util.ResourceBundle
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -24,6 +22,8 @@ import uk.ryanwong.gmap2ics.app.usecases.GetPlaceVisitVEventUseCase
 import uk.ryanwong.gmap2ics.data.repository.LocalFileRepository
 import uk.ryanwong.gmap2ics.data.repository.TimelineRepository
 import uk.ryanwong.gmap2ics.ui.screens.MainScreenUIState
+import java.nio.file.Paths
+import java.util.ResourceBundle
 
 class MainScreenViewModel(
     private val configFile: Config,

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModelTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModelTest.kt
@@ -4,11 +4,16 @@
 
 package uk.ryanwong.gmap2ics.ui.viewmodels
 
+import dev.icerock.moko.mvvm.test.TestViewModelScope
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -74,17 +79,28 @@ internal class MainScreenViewModelTest : FreeSpec() {
         mockGetPlaceVisitVEventUseCase = MockGetPlaceVisitVEventUseCase()
         mockResourceBundle = mockk()
 
-        mainScreenViewModel = MainScreenViewModel(
-            configFile = MockConfig(),
-            timelineRepository = mockTimelineRepository,
-            localFileRepository = mockLocalFileRepository,
-            getActivitySegmentVEventUseCase = mockGetActivitySegmentVEventUseCase,
-            getOutputFilenameUseCase = mockGetOutputFilenameUseCase,
-            getPlaceVisitVEventUseCase = mockGetPlaceVisitVEventUseCase,
-            resourceBundle = mockResourceBundle,
-            projectBasePath = mockProjectBasePath,
-            dispatcher = UnconfinedTestDispatcher(),
-        )
+        mainScreenViewModel =
+            MainScreenViewModel(
+                configFile = MockConfig(),
+                timelineRepository = mockTimelineRepository,
+                localFileRepository = mockLocalFileRepository,
+                getActivitySegmentVEventUseCase = mockGetActivitySegmentVEventUseCase,
+                getOutputFilenameUseCase = mockGetOutputFilenameUseCase,
+                getPlaceVisitVEventUseCase = mockGetPlaceVisitVEventUseCase,
+                resourceBundle = mockResourceBundle,
+                projectBasePath = mockProjectBasePath,
+                dispatcher = UnconfinedTestDispatcher(),
+            )
+    }
+
+    override suspend fun beforeEach(testCase: TestCase) {
+        super.beforeEach(testCase)
+        TestViewModelScope.setupViewModelScope(CoroutineScope(Dispatchers.Unconfined))
+    }
+
+    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+        super.afterEach(testCase, result)
+        TestViewModelScope.resetViewModelScope()
     }
 
     init {


### PR DESCRIPTION
Probably the last PR in 2023. A quick refactor to apply MoKo MVVM, so that we don't have to manage the viewmodelScope by ourselves.

Potentally as we use more existing KMP components, we are able to also try building a web version of this app.