### PR TITLE
[chore] kover: fix configuration to ignore untestable classes

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -121,9 +121,9 @@ koverReport {
             // excludes all classes located in specified package and it subpackages, wildcards '*' and '?' are available
             packages(
                 listOf(
-                    "uk.ryanwong.gmap2ics.app.configs.*",
-                    "uk.ryanwong.gmap2ics.ui.screens.*",
-                    "uk.ryanwong.gmap2ics.ui.theme.*",
+                    "uk.ryanwong.gmap2ics.app.configs",
+                    "uk.ryanwong.gmap2ics.ui.screens",
+                    "uk.ryanwong.gmap2ics.ui.theme",
                 ),
             )
         }


### PR DESCRIPTION
kover was broken since we upgraded it. fixed the configuration for ignored packages - thie raises the coverage. 