### PR TITLE
[fix] Fix Gradle to allow running app from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ calendars.
 By doing so, I can keep a full record for the places I have actually been, and also the rough mileages I have spent on
 the road.
 
-## Skills covered:
+## Skills covered
 
 Trying to reuse all my Android development knowledge as possible, otherwise native replacements have been applied.
 
@@ -93,3 +93,10 @@ Trying to reuse all my Android development knowledge as possible, otherwise nati
    output paths.
 8. If you have created your own configuration file, update the file path in `Main.kt`
 9. Run the project on IntelliJ IDEA
+
+### Running the app
+
+There is a plan to deprecate the configuration file automate the app build process. However, before that happened, 
+you still have to properly maintain your own configuration file to build and run the app.
+
+To start the app from command line: `./gradlew runReleaseDistributable`

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -96,7 +96,7 @@ kotlin {
 
 compose.desktop {
     application {
-        mainClass = "MainKt"
+        mainClass = "uk.ryanwong.gmap2ics.MainKt"
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)


### PR DESCRIPTION
The Gradle build script has been incorrect so we have not been able to start the app from command line.
A small change to fix this, which paves the way to implement automatic app build on CI (dependency: split configuration from the build process).