### PR TITLE
CI: add gradle dependency submission action

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,22 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3


### PR DESCRIPTION
Adding the Gradle Dependency Submission Github action to the repository. It does not supply any build credentials. In case it fails, a separate ticket to fix the app build allowing a credential free build is required.