### PR TITLE
ci: skip Gradle for non-app Renovate updates, enable signed platformCommit

### DIFF
--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -13,7 +13,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Skips the Gradle steps below entirely for updates that can't
+      # possibly affect the app (GitHub Actions digest bumps, etc.) - so
+      # e.g. an action digest bump doesn't pay for a full Gradle build it
+      # has no way of affecting.
+      - name: Detect build-relevant changes
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
+        with:
+          base: main
+          filters: |
+            code:
+              - 'composeApp/**'
+              - 'gradle/**'
+              - '*.gradle.kts'
+              - 'gradle.properties'
+
       - name: set up JDK 17
+        if: steps.filter.outputs.code == 'true'
         uses: actions/setup-java@v6
         with:
           distribution: 'corretto'
@@ -21,13 +38,17 @@ jobs:
           cache: gradle
 
       - name: Copy ConfigProvider for CI
+        if: steps.filter.outputs.code == 'true'
         run: cp composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/app/configs/ProvideConfig.kt composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/app/configs/ProvideConfig.kt
 
       - name: Grant execute permission for gradlew
+        if: steps.filter.outputs.code == 'true'
         run: chmod +x gradlew
 
       - name: Install Xvfb
+        if: steps.filter.outputs.code == 'true'
         run: sudo apt-get install -y xvfb
 
       - name: Gradle Check
+        if: steps.filter.outputs.code == 'true'
         run: xvfb-run ./gradlew check

--- a/renovate.json
+++ b/renovate.json
@@ -41,5 +41,6 @@
   ],
   "automerge": true,
   "platformAutomerge": true,
-  "automergeType": "branch"
+  "automergeType": "branch",
+  "platformCommit": "enabled"
 }


### PR DESCRIPTION
Fleet-wide uniform application — same pattern as sibling repos this session.